### PR TITLE
Fix g1 model mass error

### DIFF
--- a/assets/hands/g1_fingers.xml
+++ b/assets/hands/g1_fingers.xml
@@ -221,6 +221,7 @@
   <!-- ===================== FORCE SENSOR SITES ===================== -->
   <!-- Gauche -->
   <body name="left_thumb_force_sensors" pos="0.02 0 0">
+    <inertial pos="0 0 0" mass="0.001" diaginertia="1e-8 1e-8 1e-8"/>
     <site name="left_thumb_force_sensor_0_site"
           pos="0 0 0"
           size="0.003"
@@ -251,6 +252,7 @@
   </body>
 
   <body name="left_index_force_sensors" pos="0.02 0 0">
+    <inertial pos="0 0 0" mass="0.001" diaginertia="1e-8 1e-8 1e-8"/>
     <site name="left_index_force_sensor_0_site"
           pos="0 0 0"
           size="0.003"
@@ -281,6 +283,7 @@
   </body>
 
   <body name="left_middle_force_sensors" pos="0.02 0 0">
+    <inertial pos="0 0 0" mass="0.001" diaginertia="1e-8 1e-8 1e-8"/>
     <site name="left_middle_force_sensor_0_site"
           pos="0 0 0"
           size="0.003"
@@ -311,6 +314,7 @@
   </body>
 
   <body name="left_ring_force_sensors" pos="0.02 0 0">
+    <inertial pos="0 0 0" mass="0.001" diaginertia="1e-8 1e-8 1e-8"/>
     <site name="left_ring_force_sensor_0_site"
           pos="0 0 0"
           size="0.003"
@@ -342,6 +346,7 @@
 
   <!-- Droite -->
   <body name="right_thumb_force_sensors" pos="0.02 0 0">
+    <inertial pos="0 0 0" mass="0.001" diaginertia="1e-8 1e-8 1e-8"/>
     <site name="right_thumb_force_sensor_0_site"
           pos="0 0 0"
           size="0.003"
@@ -372,6 +377,7 @@
   </body>
 
   <body name="right_index_force_sensors" pos="0.02 0 0">
+    <inertial pos="0 0 0" mass="0.001" diaginertia="1e-8 1e-8 1e-8"/>
     <site name="right_index_force_sensor_0_site"
           pos="0 0 0"
           size="0.003"
@@ -402,6 +408,7 @@
   </body>
 
   <body name="right_middle_force_sensors" pos="0.02 0 0">
+    <inertial pos="0 0 0" mass="0.001" diaginertia="1e-8 1e-8 1e-8"/>
     <site name="right_middle_force_sensor_0_site"
           pos="0 0 0"
           size="0.003"
@@ -432,6 +439,7 @@
   </body>
 
   <body name="right_ring_force_sensors" pos="0.02 0 0">
+    <inertial pos="0 0 0" mass="0.001" diaginertia="1e-8 1e-8 1e-8"/>
     <site name="right_ring_force_sensor_0_site"
           pos="0 0 0"
           size="0.003"


### PR DESCRIPTION
Add minimal inertial properties to force sensor bodies in `g1_fingers.xml` to resolve MuJoCo's "body mass is too small" error.

MuJoCo requires all `body` elements to have defined inertial properties (mass and inertia) to compute their center of mass. The `force_sensors` bodies were missing these properties, leading to a loading error. Adding a minimal mass and diagonal inertia allows the model to load correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0b65cfe-60d9-47cf-ba20-ffa0a4461be6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e0b65cfe-60d9-47cf-ba20-ffa0a4461be6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>