### PR TITLE
Corriger les erreurs de capteurs et de types dans le script d'entraînement

### DIFF
--- a/config/sac_grasp_lift.yaml
+++ b/config/sac_grasp_lift.yaml
@@ -18,33 +18,41 @@ task:
   # IDs MuJoCo critiques
   cube_body_name: "cube"
   
-  # Sensors (utilise ceux du modèle G1)
-  touch_sensors:
-    - "left_thumb_touch"
-    - "left_index_touch"
-    - "left_middle_touch"
-    - "left_ring_touch"
-    - "right_thumb_touch" 
-    - "right_index_touch"
-    - "right_middle_touch"
-    - "right_ring_touch"
+  # Sensors (désactivés car non disponibles dans le modèle G1)
+  # Les capteurs tactiles et de force ne sont pas définis dans g1_combined.xml
+  touch_sensors: []
+    # - "left_thumb_touch"
+    # - "left_index_touch"
+    # - "left_middle_touch"
+    # - "left_ring_touch"
+    # - "right_thumb_touch" 
+    # - "right_index_touch"
+    # - "right_middle_touch"
+    # - "right_ring_touch"
   
-  force_sensors:
-    - "left_thumb_force_x"
-    - "left_thumb_force_y" 
-    - "left_thumb_force_z"
-    - "left_index_force_x"
-    - "left_index_force_y"
-    - "left_index_force_z"
-    - "left_middle_force_x"
-    - "left_middle_force_y"
-    - "left_middle_force_z"
-    - "right_thumb_force_x"
-    - "right_thumb_force_y"
-    - "right_thumb_force_z"
-    - "right_index_force_x"
-    - "right_index_force_y"
-    - "right_index_force_z"
+  force_sensors: []
+    # - "left_thumb_force_x"
+    # - "left_thumb_force_y" 
+    # - "left_thumb_force_z"
+    # - "left_index_force_x"
+    # - "left_index_force_y"
+    # - "left_index_force_z"
+    # - "left_middle_force_x"
+    # - "left_middle_force_y"
+    # - "left_middle_force_z"
+    # - "right_thumb_force_x"
+    # - "right_thumb_force_y"
+    # - "right_thumb_force_z"
+    # - "right_index_force_x"
+    # - "right_index_force_y"
+    # - "right_index_force_z"
+  
+  # Sites de doigts (à définir selon le modèle G1)
+  finger_sites: []
+    # - "left_index_tip"
+    # - "left_thumb_tip"
+    # - "right_index_tip"
+    # - "right_thumb_tip"
   
   # Paramètres épisode
   max_steps_per_episode: 500

--- a/scripts/train_sac_per_ultra.py
+++ b/scripts/train_sac_per_ultra.py
@@ -284,8 +284,8 @@ class IntelligentCache:
         
         for key in self.cache:
             recency_score = current_time - self.access_times.get(key, 0)
-            frequency_score = 1.0 / (self.access_counts[key]  1)
-            scores[key] = recency_score  frequency_score
+            frequency_score = 1.0 / (self.access_counts[key] + 1)
+            scores[key] = recency_score + frequency_score
         
         # Suppression des items avec score le plus élevé (moins utiles)
         sorted_keys = sorted(scores.keys(), key=lambda k: scores[k], reverse=True)
@@ -396,13 +396,13 @@ class UltraPrioritizedReplayBuffer:
     
     def _update_tree(self, idx: int, priority: float):
         """Mise à jour segment tree efficace"""
-        tree_idx = idx  self.tree_size
+        tree_idx = idx + self.tree_size
         self.tree[tree_idx] = priority
         
         # Propagation vers racine
         while tree_idx > 1:
             tree_idx //= 2
-            self.tree[tree_idx] = self.tree[2 * tree_idx]  self.tree[2 * tree_idx  1]
+            self.tree[tree_idx] = self.tree[2 * tree_idx] + self.tree[2 * tree_idx + 1]
     
     def _get_priority_sum(self, start: int = 0, end: int = None) -> float:
         """Somme des priorités dans un range (O(log n))"""
@@ -410,17 +410,17 @@ class UltraPrioritizedReplayBuffer:
             end = self.actual_size
         
         # Conversion vers indices tree
-        start = self.tree_size
-        end = self.tree_size
+        start += self.tree_size
+        end += self.tree_size
         
         total = 0.0
         while start < end:
             if start % 2 == 1:
-                total = self.tree[start]
-                start = 1
+                total += self.tree[start]
+                start += 1
             if end % 2 == 1:
                 end -= 1
-                total = self.tree[end]
+                total += self.tree[end]
             start //= 2
             end //= 2
         
@@ -438,7 +438,7 @@ class UltraPrioritizedReplayBuffer:
         segment_size = total_priority / batch_size
         segments = np.arange(batch_size) * segment_size
         random_offsets = np.random.uniform(0, segment_size, size=batch_size)
-        samples = segments  random_offsets
+        samples = segments + random_offsets
         
         # Recherche indices correspondants dans tree
         indices = []
@@ -460,7 +460,7 @@ class UltraPrioritizedReplayBuffer:
                 tree_idx = left_child
             else:
                 value -= left_sum
-                tree_idx = left_child  1
+                tree_idx = left_child + 1
         
         return min(tree_idx - self.tree_size, self.actual_size - 1)
     
@@ -555,9 +555,9 @@ class UltraPrioritizedReplayBuffer:
             self._update_tree(self.ptr, self.max_priority)
             
             # Mise à jour état
-            self.ptr = (self.ptr  1) % self.size
-            self.actual_size = min(self.actual_size  1, self.size)
-            self.stats['total_additions'] = 1
+            self.ptr = (self.ptr + 1) % self.size
+            self.actual_size = min(self.actual_size + 1, self.size)
+            self.stats['total_additions'] += 1
             
             # Cache invalidation pour cohérence
             cache_key = f"sample_{self.stats['total_samples']}"
@@ -578,11 +578,11 @@ class UltraPrioritizedReplayBuffer:
         cached_result = self.cache.get(cache_key)
         
         if cached_result is not None:
-            self.stats['cache_hits'] = 1
+            self.stats['cache_hits'] += 1
             logger.debug("💾 Cache hit pour échantillonnage")
             return cached_result
         
-        self.stats['cache_misses'] = 1
+        self.stats['cache_misses'] += 1
         
         with self._error_recovery("sample"):
             # Échantillonnage proportionnel
@@ -590,11 +590,11 @@ class UltraPrioritizedReplayBuffer:
             
             # Calcul poids importance sampling
             total_priority = self._get_priority_sum()
-            min_priority = np.min([self.tree[i  self.tree_size] for i in indices])
+            min_priority = np.min([self.tree[i + self.tree_size] for i in indices])
             
             weights = []
             for idx in indices:
-                priority = self.tree[idx  self.tree_size]
+                priority = self.tree[idx + self.tree_size]
                 prob = priority / total_priority
                 weight = (self.actual_size * prob) ** (-self.beta)
                 weights.append(weight)
@@ -620,7 +620,7 @@ class UltraPrioritizedReplayBuffer:
             
             # Cache pour réutilisation
             self.cache.set(cache_key, result)
-            self.stats['total_samples'] = 1
+            self.stats['total_samples'] += 1
             
             return result
     
@@ -642,7 +642,7 @@ class UltraPrioritizedReplayBuffer:
             priorities = priorities_valid.metadata['tensor'].cpu().numpy()
             
             # Clipping et epsilon pour stabilité
-            priorities = np.abs(priorities)  self.epsilon
+            priorities = np.abs(priorities) + self.epsilon
             priorities = np.clip(priorities, self.epsilon, 100.0)
             
             # Mise à jour tree
@@ -651,7 +651,7 @@ class UltraPrioritizedReplayBuffer:
                     self._update_tree(idx, priority ** self.alpha)
                     self.max_priority = max(self.max_priority, priority)
             
-            self.stats['priority_updates'] = 1
+            self.stats['priority_updates'] += 1
     
     def get_stats(self) -> Dict[str, Any]:
         """Statistiques complètes du buffer"""
@@ -665,7 +665,7 @@ class UltraPrioritizedReplayBuffer:
             'total_additions': self.stats['total_additions'],
             'total_samples': self.stats['total_samples'],
             'priority_updates': self.stats['priority_updates'],
-            'cache_hit_ratio': self.stats['cache_hits'] / max(self.stats['cache_hits']  self.stats['cache_misses'], 1),
+            'cache_hit_ratio': self.stats['cache_hits'] / max(self.stats['cache_hits'] + self.stats['cache_misses'], 1),
             'cache_stats': cache_stats,
             'alpha': self.alpha,
             'beta': self.beta
@@ -806,11 +806,11 @@ class UltraAdvancedSACAgent:
                 super().__init__()
                 
                 # Normalisation d'entrée
-                self.input_norm = nn.LayerNorm(obs_dim  act_dim)
+                self.input_norm = nn.LayerNorm(obs_dim + act_dim)
                 
                 # Trunk partagé
                 layers = []
-                in_dim = obs_dim  act_dim
+                in_dim = obs_dim + act_dim
                 
                 for hidden_size in hidden_sizes:
                     layers.extend([
@@ -847,7 +847,7 @@ class UltraAdvancedSACAgent:
                 advantage = self.advantage_head(features)
                 
                 # Dueling: Q = V  A - mean(A)
-                q_value = value  advantage - advantage.mean(dim=-1, keepdim=True)
+                q_value = value + advantage - advantage.mean(dim=-1, keepdim=True)
                 
                 return q_value.squeeze(-1)
         
@@ -1112,7 +1112,7 @@ class UltraSACPERTrainer:
             yield
         finally:
             self.timers[name] = time.time() - start
-            self.counters[name] = 1
+            self.counters[name] += 1
     
     def _emergency_save(self):
         """Sauvegarde d'urgence en cas de problème"""
@@ -1136,7 +1136,7 @@ class UltraSACPERTrainer:
         """Mise à jour β pour PER avec annealing"""
         if self.per_beta_annealing:
             progress = min(self.step_count / self.total_steps, 1.0)
-            self.buffer.beta = self.per_beta_start  progress * (self.per_beta_end - self.per_beta_start)
+            self.buffer.beta = self.per_beta_start + progress * (self.per_beta_end - self.per_beta_start)
     
     def train(self):
         """Boucle d'entraînement ultra-robuste avec recovery automatique"""
@@ -1184,15 +1184,15 @@ class UltraSACPERTrainer:
                             logger.warning("⚠️  Échec stockage buffer")
                     
                     # Mise à jour métriques épisode
-                    episode_reward = reward
-                    episode_length = 1
+                    episode_reward += reward
+                    episode_length += 1
                     obs = next_obs
                     
                     # === FIN D'ÉPISODE ===
                     if done:
                         self.metrics['episode_rewards'].append(episode_reward)
                         self.metrics['episode_lengths'].append(episode_length)
-                        self.episode_count = 1
+                        self.episode_count += 1
                         
                         # Logging épisode
                         if self.episode_count % 10 == 0:
@@ -1309,7 +1309,7 @@ class UltraSACPERTrainer:
                     min_q_next = torch.min(q1_next, q2_next)
                     
                     alpha = torch.exp(self.agent.log_alpha)
-                    target_q = batch['rew']  self.gamma * (~batch['done']) * (min_q_next - alpha * next_log_probs)
+                    target_q = batch['rew'] + self.gamma * (~batch['done']) * (min_q_next - alpha * next_log_probs)
                 
                 # Mise à jour Q1 avec PER weights
                 q1_pred = self.agent.q1(batch['obs'], batch['act'])
@@ -1348,7 +1348,7 @@ class UltraSACPERTrainer:
                 self.agent.policy_optimizer.step()
                 
                 # === ENTROPIE ADAPTATIVE ===
-                alpha_loss = -(self.agent.log_alpha * (log_probs  self.agent.target_entropy).detach()).mean()
+                alpha_loss = -(self.agent.log_alpha * (log_probs + self.agent.target_entropy).detach()).mean()
                 
                 self.agent.alpha_optimizer.zero_grad()
                 alpha_loss.backward()

--- a/tasks/grasp/grasp_lift_task_optimized.py
+++ b/tasks/grasp/grasp_lift_task_optimized.py
@@ -133,7 +133,7 @@ class RewardShaper:
         force_magnitudes = np.linalg.norm(forces.reshape(-1, 3), axis=1)
         
         # Sigmoid pour contact progressif
-        contact_rewards = 1.0 / (1.0  + np.exp(-(force_magnitudes - self.contact_threshold) * 5))
+        contact_rewards = 1.0 / (1.0 + np.exp(-(force_magnitudes - self.contact_threshold) * 5))
         base_contact = np.mean(contact_rewards)
         
         # Pénalité déséquilibre (encourage symétrie)
@@ -144,7 +144,7 @@ class RewardShaper:
             balance_penalty = 1.0
             
         # Pénalité force excessive (évite damage)
-        max_force = np.max(force_magnitudes) 
+        max_force = np.max(force_magnitudes) if len(force_magnitudes) > 0 else 0.0
         excessive_penalty = 1.0 if max_force < 10.0 else np.exp(-(max_force - 10.0))
         
         total_reward = base_contact * balance_penalty * excessive_penalty
@@ -154,7 +154,7 @@ class RewardShaper:
             'balance_penalty': balance_penalty,
             'excessive_penalty': excessive_penalty,
             'max_force': max_force,
-            'avg_force': np.mean(force_magnitudes)
+            'avg_force': np.mean(force_magnitudes) if len(force_magnitudes) > 0 else 0.0
         }
         
         return total_reward, info
@@ -170,7 +170,7 @@ class RewardShaper:
         
         # 1. Symétrie des forces
         if len(force_magnitudes) >= 2:
-            force_symmetry = 1.0 - (np.std(force_magnitudes) / (np.mean(force_magnitudes)  1e-6))
+            force_symmetry = 1.0 - (np.std(force_magnitudes) / (np.mean(force_magnitudes) + 1e-6))
         else:
             force_symmetry = 0.0
             
@@ -187,8 +187,8 @@ class RewardShaper:
         force_closure = np.tanh(total_force / 2.0)  # Saturation à 2N total
         
         # Combinaison pondérée
-        grasp_quality = (0.4 * force_symmetry  
-                        0.3 * geometric_quality  
+        grasp_quality = (0.4 * force_symmetry + 
+                        0.3 * geometric_quality + 
                         0.3 * force_closure)
         
         info = {
@@ -225,7 +225,7 @@ class RewardShaper:
         else:
             height_maintenance = height_progress
             
-        lift_reward = height_progress * velocity_penalty  0.5 * height_maintenance
+        lift_reward = height_progress * velocity_penalty + 0.5 * height_maintenance
         
         info = {
             'height_progress': height_progress,
@@ -254,7 +254,7 @@ class RewardShaper:
                 r = R.from_quat(cube_orientation)
                 euler = r.as_euler('xyz')
                 # Pénalise rotation X et Y (tilt), permet Z (yaw)
-                tilt_magnitude = np.sqrt(euler[0]**2  euler[1]**2)
+                tilt_magnitude = np.sqrt(euler[0]**2 + euler[1]**2)
                 orientation_bonus = np.exp(-tilt_magnitude * 5)
             else:
                 orientation_bonus = 1.0
@@ -284,7 +284,7 @@ class RewardShaper:
         # Pénalité longueur épisode (encourage efficacité)
         length_penalty = -0.001 * episode_length
         
-        efficiency_reward = action_penalty  length_penalty
+        efficiency_reward = action_penalty + length_penalty
         
         info = {
             'action_penalty': action_penalty,
@@ -317,11 +317,11 @@ class RewardShaper:
         
         # Reward pondéré
         weighted_reward = (
-            self.adaptive_weights['contact'] * contact_r 
-            self.adaptive_weights['grasp'] * grasp_r 
-            self.adaptive_weights['lift'] * lift_r 
-            self.adaptive_weights['stability'] * stability_r 
-            self.adaptive_weights['efficiency'] * efficiency_r 
+            self.adaptive_weights['contact'] * contact_r +
+            self.adaptive_weights['grasp'] * grasp_r +
+            self.adaptive_weights['lift'] * lift_r +
+            self.adaptive_weights['stability'] * stability_r +
+            self.adaptive_weights['efficiency'] * efficiency_r +
             success_bonus
         )
         
@@ -489,8 +489,8 @@ class ObservationProcessor:
         magnitudes_norm = np.clip(force_magnitudes / self.force_max, 0.0, 1.0)
         
         # Features dérivées
-        total_force = np.sum(force_magnitudes)
-        max_force = np.max(force_magnitudes)
+        total_force = np.sum(force_magnitudes) if len(force_magnitudes) > 0 else 0.0
+        max_force = np.max(force_magnitudes) if len(force_magnitudes) > 0 else 0.0
         force_std = np.std(force_magnitudes) if len(force_magnitudes) > 1 else 0.0
         
         # Normalisation features dérivées
@@ -553,7 +553,7 @@ class ObservationProcessor:
                 
                 # Direction cube-finger (vecteur unitaire)
                 direction = finger_pos - cube_pos
-                direction_norm = direction / (np.linalg.norm(direction)  1e-6)
+                direction_norm = direction / (np.linalg.norm(direction) + 1e-6)
                 
                 cube_finger_features.extend([distance_norm])
                 cube_finger_features.extend(direction_norm)
@@ -679,8 +679,8 @@ class SuccessDetector:
     def check_contact_criteria(self, forces: np.ndarray) -> Tuple[bool, float, Dict]:
         """Vérification critères de contact"""
         force_magnitudes = np.linalg.norm(forces.reshape(-1, 3), axis=1)
-        max_force = np.max(force_magnitudes)
-        total_force = np.sum(force_magnitudes)
+        max_force = np.max(force_magnitudes) if len(force_magnitudes) > 0 else 0.0
+        total_force = np.sum(force_magnitudes) if len(force_magnitudes) > 0 else 0.0
         
         # Critères contact
         sufficient_force = total_force > self.force_min
@@ -724,7 +724,7 @@ class SuccessDetector:
         
         # Symétrie forces
         if len(force_magnitudes) >= 2:
-            force_symmetry = 1.0 - (np.std(force_magnitudes) / (np.mean(force_magnitudes)  1e-6))
+            force_symmetry = 1.0 - (np.std(force_magnitudes) / (np.mean(force_magnitudes) + 1e-6))
             force_symmetry = np.clip(force_symmetry, 0.0, 1.0)
         else:
             force_symmetry = 0.0
@@ -748,8 +748,8 @@ class SuccessDetector:
         grasp_success = stable_forces and symmetric_forces and good_geometry
         
         # Confidence grasp
-        confidence = (force_stability * 0.4  
-                     force_symmetry * 0.3  
+        confidence = (force_stability * 0.4 + 
+                     force_symmetry * 0.3 + 
                      geometric_quality * 0.3)
         
         info = {
@@ -799,8 +799,8 @@ class SuccessDetector:
         stability_score = np.exp(-height_std) if len(self.height_history) >= 10 else 0.0
         movement_score = np.exp(-linear_speed) * np.exp(-angular_speed * 0.5)
         
-        confidence = (height_score * 0.4  
-                     stability_score * 0.3  
+        confidence = (height_score * 0.4 + 
+                     stability_score * 0.3 + 
                      movement_score * 0.3)
         
         info = {
@@ -841,15 +841,15 @@ class SuccessDetector:
         overall_success = contact_ok and grasp_ok and lift_ok
         
         # Confidence globale (moyenne pondérée)
-        overall_confidence = (contact_conf * 0.2  
-                            grasp_conf * 0.3  
+        overall_confidence = (contact_conf * 0.2 + 
+                            grasp_conf * 0.3 + 
                             lift_conf * 0.5)
         
         # Tracking stabilité succès
         self.success_history.append(overall_success)
         
         if overall_success:
-            self.consecutive_success_frames = 1
+            self.consecutive_success_frames += 1
         else:
             self.consecutive_success_frames = 0
         
@@ -965,7 +965,7 @@ class GraspLiftTaskOptimized:
             touch_sensors = self.config.get('touch_sensors', [])
             force_sensors = self.config.get('force_sensors', [])
             
-            for sensor_name in touch_sensors  force_sensors:
+            for sensor_name in touch_sensors + force_sensors:
                 try:
                     sensor_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_SENSOR, sensor_name)
                     if sensor_id < 0:
@@ -1033,7 +1033,7 @@ class GraspLiftTaskOptimized:
             spatial_dim = 10  # cube pos/orient/vel  relations
             contextual_dim = 5  # progress, difficulty, etc.
             
-            estimated_dim = joint_dim  force_dim  spatial_dim  contextual_dim
+            estimated_dim = joint_dim + force_dim + spatial_dim + contextual_dim
             logger.warning(f"⚠️  Obs dim estimée: {estimated_dim}")
             return estimated_dim
     
@@ -1080,20 +1080,23 @@ class GraspLiftTaskOptimized:
             for sensor_id in self.force_ids:
                 sensor_adr = self.model.sensor_adr[sensor_id]
                 sensor_dim = self.model.sensor_dim[sensor_id]
-                sensor_values = self.data.sensordata[sensor_adr:sensor_adrsensor_dim]
+                sensor_values = self.data.sensordata[sensor_adr:sensor_adr+sensor_dim]
                 force_data.append(sensor_values)
             
             # Concaténation et reshape
-            forces = np.concatenate(force_data) if force_data else np.zeros(0)
-            
-            # Filtrage outliers (clipping sécurisé)
-            forces = np.clip(forces, -50.0, 50.0)
+            if force_data:
+                forces = np.concatenate(force_data)
+                # Filtrage outliers (clipping sécurisé)
+                forces = np.clip(forces, -50.0, 50.0)
+            else:
+                forces = np.zeros(0, dtype=np.float32)
             
             return forces.astype(np.float32)
             
         except Exception as e:
             logger.error(f"❌ Erreur lecture forces: {e}")
-            return np.zeros(len(self.force_ids) * 3, dtype=np.float32)
+            # Retourne un array vide plutôt qu'un array de taille fixe
+            return np.zeros(0, dtype=np.float32)
     
     def _get_finger_positions(self) -> List[np.ndarray]:
         """Positions fingers via sites MuJoCo"""
@@ -1261,7 +1264,7 @@ class GraspLiftTaskOptimized:
             self._cache_valid = False
             
             # Incrémentation compteurs
-            self.step_count = 1
+            self.step_count += 1
             
             # Calcul reward et done
             reward, reward_info = self._compute_reward(action, done=False)
@@ -1351,7 +1354,7 @@ class GraspLiftTaskOptimized:
             
             # Adaptation difficulté
             if recent_success_rate > 0.8:
-                self.curriculum_difficulty = min(1.0, self.curriculum_difficulty  0.05)
+                self.curriculum_difficulty = min(1.0, self.curriculum_difficulty + 0.05)
             elif recent_success_rate < 0.2:
                 self.curriculum_difficulty = max(0.1, self.curriculum_difficulty - 0.05)
             
@@ -1373,7 +1376,7 @@ class GraspLiftTaskOptimized:
             )
         
         # Incrémentation compteur épisode
-        self.episode_count = 1
+        self.episode_count += 1
     
     def reset(self) -> np.ndarray:
         """
@@ -1384,7 +1387,7 @@ class GraspLiftTaskOptimized:
         try:
             # Reset compteurs step
             self.step_count = 0
-            self.reset_count = 1
+            self.reset_count += 1
             
             # Reset état MuJoCo
             mujoco.mj_resetData(self.model, self.data)
@@ -1440,7 +1443,7 @@ class GraspLiftTaskOptimized:
             # Position aléatoire
             cube_pos_noise = np.random.uniform(-pos_noise_scale, pos_noise_scale, 3)
             cube_pos_noise[2] *= 0.5  # Moins de variation en Z
-            new_cube_pos = base_pos  cube_pos_noise
+            new_cube_pos = base_pos + cube_pos_noise
             
             # Orientation aléatoire (quaternion)
             if orientation_noise_scale > 0:
@@ -1458,7 +1461,7 @@ class GraspLiftTaskOptimized:
             joint_noise_scale = 0.1 * self.curriculum_difficulty
             if joint_noise_scale > 0:
                 joint_noise = np.random.uniform(-joint_noise_scale, joint_noise_scale, self.model.nv)
-                self.data.qpos[:] = joint_noise
+                self.data.qpos[:] += joint_noise
                 self.data.qpos[:] = np.clip(self.data.qpos, -2*np.pi, 2*np.pi)  # Sécurité
             
             # Forward kinematics pour cohérence


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes multiple errors in the SAC-PER training system, including missing sensor configurations, zero-size array operations, and widespread syntax issues, to enable successful model training.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The training script `train_sac_per_ultra.py` and its associated task `GraspLiftTaskOptimized` encountered several critical issues:
1.  **Sensor Configuration**: The `config/sac_grasp_lift.yaml` file specified touch and force sensors that were not present in the G1 MuJoCo model, leading to warnings and empty sensor data arrays. These have been disabled in the config.
2.  **Zero-size Array Operations**: Operations like `np.max()` and `np.mean()` were called on these empty sensor data arrays, causing runtime errors. Guards have been added to handle empty arrays gracefully.
3.  **Syntax Errors**: A significant number of `+` operators were malformed as ` ` (likely due to encoding issues), resulting in `SyntaxError` and incorrect arithmetic throughout the codebase. All identified instances have been corrected.
4.  **Incorrect Incrementation**: Several counters were incorrectly assigned with `= 1` instead of being incremented with `+= 1`, affecting metrics and progress tracking. These have been fixed.

This comprehensive set of fixes ensures the script can now run without the reported fatal errors and proceed with the training process.

---
<a href="https://cursor.com/background-agent?bcId=bc-2365da04-b229-405d-baca-d0670ea68c97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2365da04-b229-405d-baca-d0670ea68c97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>