### PR TITLE
Test corrected system for xml error

### DIFF
--- a/assets/hands/g1_fingers.xml
+++ b/assets/hands/g1_fingers.xml
@@ -1,5 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
 <mujoco model="g1_fingers">
+  <default class="finger">
+    <!-- Add any default parameters for finger geoms/joints here if needed -->
+  </default>
   <asset>
     <mesh name="left_thumb_0_mesh" file="meshes/left_thumb_1.STL" />
     <mesh name="left_thumb_1_mesh" file="meshes/left_thumb_2.STL" />


### PR DESCRIPTION
Add missing default class 'finger' to `g1_fingers.xml` to resolve MuJoCo XML error.

---
<a href="https://cursor.com/background-agent?bcId=bc-92ed9602-1e24-432c-a64c-1b4696e9e63d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-92ed9602-1e24-432c-a64c-1b4696e9e63d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

