### PR TITLE
Test corrected system environment error

### DIFF
--- a/assets/hands/g1_fingers.xml
+++ b/assets/hands/g1_fingers.xml
@@ -1,5 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
 <mujoco model="g1_fingers">
+  <default class="finger">
+    <joint type="hinge" damping="0.01" frictionloss="0.01" range="0 1.5"/>
+    <geom contype="1" conaffinity="1"/>
+  </default>
   <asset>
     <mesh name="left_thumb_0_mesh" file="meshes/left_thumb_1.STL" />
     <mesh name="left_thumb_1_mesh" file="meshes/left_thumb_2.STL" />


### PR DESCRIPTION
Add missing 'finger' default class definition to resolve XML parsing error.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc93b069-3120-4617-84f1-ac627f2d863a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc93b069-3120-4617-84f1-ac627f2d863a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

